### PR TITLE
Fix TimSort invariants (fixes #8)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ end
 
 srand(0xdeadbeef)
 
-for n in [0:10, 100, 101, 1000, 1001]
+for n in [0:10..., 100, 101, 1000, 1001]
     r = 1:10
     v = rand(1:10,n)
     h = hist(v,r)


### PR DESCRIPTION
* http://envisage-project.eu/proving-android-java-and-python-sorting-algorithm-is-broken-and-how-to-fix-it/

As pointed out in #8, we aren't as affected as python and java, in the sense that we won't overflow a fixed-sized array.  But this fixes the invariant test.