### PR TITLE
Fix deprecation warnings, remove v0.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4
 Compat 0.8.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3
-Compat
+Compat 0.8.4

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -1,6 +1,7 @@
 module SortingAlgorithms
 
 using Compat
+import Compat.view
 using Base.Sort
 using Base.Order
 
@@ -22,7 +23,7 @@ const RadixSort = RadixSortAlg()
 
 function sort!(v::AbstractVector, lo::Int, hi::Int, a::HeapSortAlg, o::Ordering)
     if lo > 1 || hi < length(v)
-        return sort!(sub(v, lo:hi), 1, length(v), a, o)
+        return sort!(view(v, lo:hi), 1, length(v), a, o)
     end
     r = ReverseOrdering(o)
     heapify!(v, r)
@@ -548,7 +549,7 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, ::TimSortAlg, o::Ordering)
         else
             if !issorted(run_range)
                 run_range = last(run_range):first(run_range)
-                reverse!(sub(v, run_range))
+                reverse!(view(v, run_range))
             end
         end
         # Push this run onto the queue and merge if needed

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+StatsBase 0.9.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test
 using SortingAlgorithms
 using Compat
+using StatsBase
 
 a = rand(1:10000, 1000)
 
@@ -56,14 +57,14 @@ srand(0xdeadbeef)
 for n in [0:10..., 100, 101, 1000, 1001]
     r = 1:10
     v = rand(1:10,n)
-    h = hist(v,r)
+    h = fit(Histogram, v, r)
 
     for ord in [Base.Order.Forward, Base.Order.Reverse]
         # insertion sort (stable) as reference
         pi = sortperm(v, alg=InsertionSort, order=ord)
         @test isperm(pi)
         si = v[pi]
-        @test hist(si,r) == h
+        @test fit(Histogram, si, r) == h
         @test issorted(si, order=ord)
         @test all(issorted,[pi[si.==x] for x in r])
         c = copy(v)


### PR DESCRIPTION
Add REQUIRE file to tests for StatsBase, because `hist` is deprecated, and `sub` is now `view`